### PR TITLE
init.lua: Doesn't load if unifieddyes isn't found

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,3 +1,8 @@
+if not minetest.global_exists("unifieddyes") then
+	minetest.log("error", "[MOD/plasticbox] plasticbox requires that unifieddyes be installed, which wasn't detected. As a result, the plasticbox mod will not load.");
+	return
+end
+
 minetest.register_node("plasticbox:plasticbox", {
 	description = "Plastic Box",
 	tiles = {"plasticbox_white.png"},


### PR DESCRIPTION
This PR makes it such that `plasticbox` won't load if `unifieddyes` isn't detected, with a helpful error message to aid server administrators in figuring out what's gone wrong.