### PR TITLE
Make homedecor dependency optional

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,3 +1,3 @@
-homedecor
+homedecor?
 moreblocks?
 unifieddyes

--- a/init.lua
+++ b/init.lua
@@ -21,14 +21,16 @@ if minetest.global_exists("stairsplus") then
 	})
 end
 
-minetest.register_craft( {
-        output = "plasticbox:plasticbox 4",
-        recipe = {
-                { "homedecor:plastic_sheeting", "homedecor:plastic_sheeting", "homedecor:plastic_sheeting" },
-                { "homedecor:plastic_sheeting", "", "homedecor:plastic_sheeting" },
-                { "homedecor:plastic_sheeting", "homedecor:plastic_sheeting", "homedecor:plastic_sheeting" }
-        },
-})
+if minetest.global_exists("homedecor") then
+	minetest.register_craft( {
+	        output = "plasticbox:plasticbox 4",
+	        recipe = {
+	                { "homedecor:plastic_sheeting", "homedecor:plastic_sheeting", "homedecor:plastic_sheeting" },
+	                { "homedecor:plastic_sheeting", "", "homedecor:plastic_sheeting" },
+	                { "homedecor:plastic_sheeting", "homedecor:plastic_sheeting", "homedecor:plastic_sheeting" }
+	        },
+	})
+end
 
 minetest.register_lbm({
 	name = "plasticbox:convert_colors",


### PR DESCRIPTION
This PR makes the `homedecor` dependency optional by only registering the crafting recipe if `homedecor` is installed.